### PR TITLE
increased upload maximum size (at least to accept apks that exceeds t…

### DIFF
--- a/piprecious/piprecious/settings/base.py
+++ b/piprecious/piprecious/settings/base.py
@@ -96,3 +96,5 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = '/static/'
+
+DATA_UPLOAD_MAX_MEMORY_SIZE = 100 * 1024 * 1024


### PR DESCRIPTION
…he default 2.5MB in size)

django doc ref: https://docs.djangoproject.com/en/2.1/ref/settings/#data-upload-max-memory-size